### PR TITLE
Generate worklist when output filename is .wl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gdt2dicom"
 version = "0.1.0"
 edition = "2021"
+default-run = "gdt2dicom"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,30 @@
+use std::ffi::OsStr;
+use std::io::Write;
+use std::process::Command;
+use std::process::Output;
+
+pub fn exec_command<I, S>(
+    command: &str,
+    arguments: I,
+    print: bool,
+) -> Result<Output, std::io::Error>
+where
+    I: IntoIterator<Item = S> + Clone,
+    S: AsRef<OsStr>,
+{
+    let x = arguments.clone();
+    println!(
+        "Running: {} {}",
+        &command,
+        &x.into_iter()
+            .map(|s| s.as_ref().to_os_string().into_string().unwrap())
+            .collect::<Vec<_>>()
+            .join(" "),
+    );
+    let output = Command::new(command).args(arguments).output()?;
+    if print {
+        std::io::stdout().write_all(&output.stdout).unwrap();
+        std::io::stderr().write_all(&output.stderr).unwrap();
+    }
+    return Ok(output);
+}

--- a/src/dcm_worklist.rs
+++ b/src/dcm_worklist.rs
@@ -1,0 +1,41 @@
+use std::ffi::OsStr;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
+
+use crate::command::exec_command;
+
+pub fn dcm_xml_to_worklist(
+    xml_file_path: &Path,
+    output_path: &PathBuf,
+) -> Result<(), std::io::Error> {
+    // This function is same as this bash:
+    // $ xml2dcm [xml_file_path] [temp1]
+    // $ cmdump [temp1] > [temp2]
+    // $ dump2dcm -g [temp2] wklist1.wl
+
+    let temp_dcm_file = NamedTempFile::new()?;
+    let temp_dcm_file_path = temp_dcm_file.path();
+    exec_command(
+        "xml2dcm",
+        vec![xml_file_path.as_os_str(), temp_dcm_file_path.as_os_str()],
+        true,
+    )?;
+
+    let mut temp_dump_file = NamedTempFile::new()?;
+
+    let output = exec_command("dcmdump", vec![temp_dcm_file_path.as_os_str()], false)?;
+    std::io::stderr().write_all(&output.stderr).unwrap();
+    temp_dump_file.write_all(&output.stdout)?;
+
+    exec_command(
+        "dump2dcm",
+        vec![
+            OsStr::new("-g"),
+            temp_dump_file.path().as_os_str(),
+            output_path.as_path().as_os_str(),
+        ],
+        true,
+    )?;
+    return Ok(());
+}

--- a/src/dcm_xml.rs
+++ b/src/dcm_xml.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -11,6 +12,7 @@ use xml::reader::EventReader;
 use xml::reader::XmlEvent;
 use xml::writer::EventWriter;
 
+use crate::command::exec_command;
 use crate::gdt::{GdtBasicDiagnosticsObject, GdtFile, GdtPatientGender, GdtPatientObject};
 
 #[derive(Debug)]
@@ -46,15 +48,17 @@ pub fn parse_dcm_as_xml(path: &PathBuf) -> Result<Vec<XmlEvent>, DcmError> {
 }
 
 pub fn export_images_from_dcm(dcm_path: &PathBuf, output_path: &PathBuf) -> Result<(), DcmError> {
-    let output = Command::new("dcmj2pnm")
-        .arg("--write-png")
-        .arg(dcm_path)
-        .arg(output_path)
-        .arg("--all-frames")
-        .output()
-        .map_err(DcmError::IoError)?;
-    std::io::stderr().write_all(&output.stderr).unwrap();
-    std::io::stdout().write_all(&output.stdout).unwrap();
+    exec_command(
+        "dcmj2pnm",
+        vec![
+            OsStr::new("--write-png"),
+            dcm_path.as_os_str(),
+            output_path.as_os_str(),
+            OsStr::new("--all-frames"),
+        ],
+        true,
+    )
+    .map_err(DcmError::IoError)?;
     return Ok(());
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod command;
+pub mod dcm_worklist;
 pub mod dcm_xml;
 pub mod gdt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod command;
 pub mod dcm_xml;
 pub mod gdt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ fn main() -> Result<(), std::io::Error> {
         if jpegs.len() > 0 {
             println!("{} Jpeg files will be ignored", jpegs.len());
         }
+        dcm_xml_to_worklist(&temp_file.path(), &args.output)?;
     } else {
         let mut command_args = vec![
             OsStr::new("-nsc"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@ use clap::Parser;
 
 use std::ffi::OsStr;
 use std::fs::read_dir;
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
+use gdt2dicom::command::exec_command;
+use gdt2dicom::dcm_worklist::dcm_xml_to_worklist;
 use gdt2dicom::dcm_xml::{default_dcm_xml, file_to_xml, parse_dcm_xml};
 use gdt2dicom::gdt::parse_file;
 
@@ -20,7 +20,7 @@ struct Args {
     dicom_xml: Option<PathBuf>,
 
     #[arg(short, long)]
-    jpegs: PathBuf,
+    jpegs: Option<PathBuf>,
 
     #[arg(short, long)]
     output: PathBuf,
@@ -28,9 +28,13 @@ struct Args {
 
 fn main() -> Result<(), std::io::Error> {
     let args = Args::parse();
-    let jpegs = list_jpeg_files(&args.jpegs)?;
+    let jpegs = match args.jpegs {
+        Some(ref j) => list_jpeg_files(&j)?,
+        None => vec![],
+    };
     println!(
-        "Found Jpeg files: \n{}",
+        "Found {} Jpeg files: \n{}",
+        jpegs.len(),
         jpegs
             .iter()
             .map(|s| s.as_path().display().to_string())
@@ -38,12 +42,13 @@ fn main() -> Result<(), std::io::Error> {
             .join("\n")
     );
 
-    let dicom_xml_path = match args.dicom_xml {
-        Some(p) => Some(PathBuf::from(p)),
-        None => find_xml_path(&args.jpegs)?,
+    let dicom_xml_path = match (args.dicom_xml, args.jpegs) {
+        (Some(p), _) => Some(PathBuf::from(p)),
+        (None, Some(ref j)) => find_xml_path(&j)?,
+        _ => None,
     };
     println!(
-        "Dicom XML file path: \n{}",
+        "Dicom XML file path: {}",
         dicom_xml_path
             .clone()
             .and_then(|p| p.into_os_string().into_string().ok())
@@ -58,25 +63,21 @@ fn main() -> Result<(), std::io::Error> {
     let gdt_file = parse_file(args.gdt_file).unwrap();
     let temp_file = file_to_xml(gdt_file, &xml_events).unwrap();
 
-    let mut command_args = vec![
-        OsStr::new("-nsc"),
-        OsStr::new("-dx"),
-        temp_file.path().as_os_str(),
-    ];
-    command_args.extend(jpegs.iter().map(|x| OsStr::new(x)));
-    command_args.push(OsStr::new(&args.output));
-
-    println!(
-        "Running: img2dcm {}",
-        command_args
-            .iter()
-            .map(|s| s.to_str().unwrap())
-            .collect::<Vec<&str>>()
-            .join(" ")
-    );
-    let output = Command::new("img2dcm").args(command_args).output()?;
-    std::io::stdout().write_all(&output.stdout).unwrap();
-    std::io::stderr().write_all(&output.stderr).unwrap();
+    if args.output.extension() == Some("wl".as_ref()) {
+        println!("Output extension is 'wl', exporting Worklist file");
+        if jpegs.len() > 0 {
+            println!("{} Jpeg files will be ignored", jpegs.len());
+        }
+    } else {
+        let mut command_args = vec![
+            OsStr::new("-nsc"),
+            OsStr::new("-dx"),
+            temp_file.path().as_os_str(),
+        ];
+        command_args.extend(jpegs.iter().map(|x| OsStr::new(x)));
+        command_args.push(OsStr::new(&args.output));
+        exec_command("img2dcm", command_args, true)?;
+    }
 
     println!("Finished");
     return Ok(());


### PR DESCRIPTION
#16

When you run `gdt2dicom` and have the ".wl" extension in `--output` option, it generates a worklist file.

```
gdt2dicom --output xxxxx.wl
```