### PR TITLE
Prefix exported images with patient id

### DIFF
--- a/src/bin/dicom2gdt.rs
+++ b/src/bin/dicom2gdt.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 
+use std::fs::create_dir_all;
 use std::path::PathBuf;
 
 use gdt2dicom::dcm_xml::{export_images_from_dcm, parse_dcm_as_xml};
@@ -16,20 +17,37 @@ struct Args {
     #[arg(short, long)]
     gdt_file: Option<PathBuf>,
 
-    /// Where to output the JPEG files
+    /// Where to output the PNG files
     #[arg(short, long)]
-    jpegs: Option<PathBuf>,
+    pngs: Option<PathBuf>,
 }
 
 fn main() -> Result<(), std::io::Error> {
     let args = Args::parse();
-    if let Some(jpegs_path) = args.jpegs {
-        println!("Exporting images to {}", &jpegs_path.display());
-        export_images_from_dcm(&args.dicom_file, &jpegs_path).unwrap();
-        println!("Exported images");
-    }
     let events = parse_dcm_as_xml(&args.dicom_file).unwrap();
     let file = dcm_xml_to_file(&events);
+    if let Some(pngs_path) = args.pngs {
+        if !pngs_path.exists() {
+            println!(
+                "Path {} doesn't exist, creating directory...",
+                pngs_path.display()
+            );
+            create_dir_all(&pngs_path)?;
+            println!("Created {}", pngs_path.display());
+        }
+        if !pngs_path.is_dir() {
+            println!(
+                "{} is not a directory, not exporting png.",
+                pngs_path.display()
+            )
+        } else {
+            let mut png_with_prefix = pngs_path.clone();
+            png_with_prefix.push(file.object_patient.patient_number.clone());
+            println!("Exporting images to {}", &png_with_prefix.display());
+            export_images_from_dcm(&args.dicom_file, &png_with_prefix).unwrap();
+            println!("Exported images");
+        }
+    }
     let gdt_string = file_to_string(file);
 
     if let Some(path) = args.gdt_file {


### PR DESCRIPTION
#52 

Weil die Bilder Dateien sind PNG nicht JPEG, ich habe `--jpegs` zu `--pngs` umbenannt.

![Screenshot 2024-03-13 at 15 54 16](https://github.com/zdavatz/gdt2dicom/assets/127193/d4c37aed-c519-4e75-a275-d2c6da9f9a40)
